### PR TITLE
Refactor difference tracking and generator logic

### DIFF
--- a/MathMax.ChangeTracking.Examples/Person.cs
+++ b/MathMax.ChangeTracking.Examples/Person.cs
@@ -9,6 +9,6 @@ public class Person
     public string FirstName { get; set; } = string.Empty;
     public string LastName { get; set; } = string.Empty;
     public DateTime DateOfBirth { get; set; }
-    public IReadOnlyList<Address> Addresses { get; set; } = [];
+    public Address? Addresses { get; set; } = new Address();
     public IReadOnlyList<Order> Orders { get; set; } = [];
 }

--- a/MathMax.ChangeTracking.Examples/Trackers/PersonChangeTracker.cs
+++ b/MathMax.ChangeTracking.Examples/Trackers/PersonChangeTracker.cs
@@ -7,7 +7,6 @@ public static class PersonChangeTracker
         // Declare the map once. Static ctor ensures this appears in compilation for generator discovery.
         ChangeTracking.Map<Person>(p =>
         {
-            p.Addresses.TrackBy(a => new { a.ZipCode, a.HouseNumber });
             p.Orders.TrackBy(o => o.OrderId, o =>
             {
                 o.Items.TrackBy(i => i.ProductId);

--- a/MathMax.ChangeTracking/ChangeTrackerExtensions.cs
+++ b/MathMax.ChangeTracking/ChangeTrackerExtensions.cs
@@ -19,6 +19,7 @@ public static class ChangeTrackerExtensions
     public static Difference CreatePropertyDifference(string path, string propertyName, object? leftOwner, object? rightOwner, object? leftValue, object? rightValue) => new()
     {
         Path = $"{path}.{propertyName}",
+        Kind = DifferenceKind.PropertyValue,
         LeftOwner = leftOwner,
         RightOwner = rightOwner,
         LeftValue = leftValue,
@@ -32,13 +33,14 @@ public static class ChangeTrackerExtensions
     /// <param name="left">The item on the left side.</param>
     /// <param name="right">The item on the right side.</param>
     /// <returns>A presence difference record.</returns>
-    public static Difference CreatePresenceDifference(string path, object? left, object? right) => new()
+    public static Difference CreatePresenceDifference(string path, object? parentOwner, object? leftValue, object? rightValue) => new()
     {
         Path = path,
-        LeftOwner = left,
-        RightOwner = right,
-        LeftValue = left,
-        RightValue = right
+        Kind = DifferenceKind.Presence,
+        LeftOwner = parentOwner,
+        RightOwner = parentOwner,
+        LeftValue = leftValue,
+        RightValue = rightValue
     };
 
     /// <summary>
@@ -56,7 +58,8 @@ public static class ChangeTrackerExtensions
     /// <returns>A sequence of differences between the two lists.</returns>
     public static IEnumerable<Difference> DiffListByIdentity<T, TKey>(IEnumerable<T> leftList, IEnumerable<T> rightList, string path,
         Func<T, T, string, IEnumerable<Difference>> perItemDiff,
-        Func<T, TKey> keySelector)
+        Func<T, TKey> keySelector,
+        object? parentOwner = null)
             where TKey : notnull
             where T : class
     {
@@ -72,7 +75,8 @@ public static class ChangeTrackerExtensions
 
             if (left == null || right == null || !inLeft || !inRight)
             {
-                yield return CreatePresenceDifference(itemPath, left, right);
+                // Parent owner is the collection (passed via parentOwner); if unknown, fall back to null.
+                yield return CreatePresenceDifference(itemPath, parentOwner, left, right);
                 continue;
             }
 

--- a/MathMax.ChangeTracking/Difference.cs
+++ b/MathMax.ChangeTracking/Difference.cs
@@ -3,11 +3,25 @@ using System.Text.Json.Serialization;
 namespace MathMax.ChangeTracking;
 
 /// <summary>
+/// Kind/classification of a produced difference entry.
+/// </summary>
+public enum DifferenceKind
+{
+    /// <summary>A change in the value of a (simple) property.</summary>
+    PropertyValue = 0,
+    /// <summary>Presence / identity difference (added / removed object, collection element, or complex child).</summary>
+    Presence = 1
+}
+
+/// <summary>
 /// Represents a single difference between two object graphs compared by the generated Diff extensions.
 /// </summary>
 public sealed class Difference
 {
     public string Path { get; set; } = string.Empty;
+
+    /// <summary>Classification of the difference.</summary>
+    public DifferenceKind Kind { get; set; }
 
     /// <summary>
     /// The object instance (left side) that owns the changed property indicated by <see cref="Path"/>.
@@ -29,5 +43,5 @@ public sealed class Difference
 
     public object? RightValue { get; set; }
 
-    public override string ToString() => $"{Path}: {LeftValue} -> {RightValue}";
+    public override string ToString() => $"[{Kind}] {Path}: {LeftValue} -> {RightValue}";
 }


### PR DESCRIPTION
Introduces a DifferenceKind enum to classify differences, updates the Difference class and related extension methods to use this kind, and improves null handling and presence difference reporting. Refactors the ChangeTrackerCodeGenerator for better modularity and correctness, including argument order fixes and more robust lambda and type handling. Updates Person and PersonChangeTracker examples to reflect changes in how addresses are tracked.